### PR TITLE
Updating the azure cli for how to show the device connection string

### DIFF
--- a/Device/.iotworkbenchproject
+++ b/Device/.iotworkbenchproject
@@ -1,1 +1,4 @@
- 
+{
+    "ProjectHostType": "Workspace",
+    "version": "1.0.0"
+}

--- a/Device/.vscode/arduino.json
+++ b/Device/.vscode/arduino.json
@@ -2,5 +2,6 @@
     "board": "AZ3166:stm32f4:MXCHIP_AZ3166",
     "configuration": "upload_method=OpenOCDMethod",
     "sketch": "GetStarted.ino",
-    "output": "./.build"
+    "output": "./.build",
+    "port": "COM3"
 }

--- a/Device/GetStarted.ino
+++ b/Device/GetStarted.ino
@@ -1,35 +1,46 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. 
 // To get started please visit https://microsoft.github.io/azure-iot-developer-kit/docs/projects/connect-iot-hub?utm_source=ArduinoExtension&utm_medium=ReleaseNote&utm_campaign=VSCode
-#include "AZ3166WiFi.h"
+#include "AZ3166WiFi.h"         //WiFi
 #include "AzureIotHub.h"
 #include "DevKitMQTTClient.h"
-
 #include "config.h"
 #include "utility.h"
 #include "SystemTickCounter.h"
 
+// Indicate whether WiFi is ready
 static bool hasWifi = false;
+
+// Temperature sensor variables
+static float temperature;
+static float humidity;
+static float pressure;
+
+// Accelerometer, pedometer variables
+
+// Magnetic variables
+
+// Message to Cloud variables
 int messageCount = 1;
 int sentMessageCount = 0;
 static bool messageSending = true;
 static uint64_t send_interval_ms;
 
-static float temperature;
-static float humidity;
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Utilities
-static void InitWifi()
+//-----------------------------------------------------------------------------------------------------------------
+static void InitWiFi()
 {
   Screen.print(2, "Connecting...");
-  
+  delay(500);
   if (WiFi.begin() == WL_CONNECTED)
   {
     IPAddress ip = WiFi.localIP();
     Screen.print(1, ip.get_address());
+    delay(500);
     hasWifi = true;
     Screen.print(2, "Running... \r\n");
+    delay(500);
   }
   else
   {
@@ -38,6 +49,7 @@ static void InitWifi()
   }
 }
 
+//-----------------------------------------------------------------------------------------------------------------
 static void SendConfirmationCallback(IOTHUB_CLIENT_CONFIRMATION_RESULT result)
 {
   if (result == IOTHUB_CLIENT_CONFIRMATION_OK)
@@ -54,15 +66,22 @@ static void SendConfirmationCallback(IOTHUB_CLIENT_CONFIRMATION_RESULT result)
   char line2[20];
   sprintf(line2, "T:%.2f H:%.2f", temperature, humidity);
   Screen.print(3, line2);
+
+  // char line3[20];
+  // sprintf(line3, "P:%.2f", pressure);
+  // Screen.print(3, line3);
+
   messageCount++;
 }
 
+//-----------------------------------------------------------------------------------------------------------------
 static void MessageCallback(const char* payLoad, int size)
 {
   blinkLED();
   Screen.print(1, payLoad, true);
 }
 
+//-----------------------------------------------------------------------------------------------------------------
 static void DeviceTwinCallback(DEVICE_TWIN_UPDATE_STATE updateState, const unsigned char *payLoad, int size)
 {
   char *temp = (char *)malloc(size + 1);
@@ -70,13 +89,15 @@ static void DeviceTwinCallback(DEVICE_TWIN_UPDATE_STATE updateState, const unsig
   {
     return;
   }
+
   memcpy(temp, payLoad, size);
   temp[size] = '\0';
   parseTwinMessage(updateState, temp);
   free(temp);
 }
 
-static int  DeviceMethodCallback(const char *methodName, const unsigned char *payload, int size, unsigned char **response, int *response_size)
+//-----------------------------------------------------------------------------------------------------------------
+static int DeviceMethodCallback(const char *methodName, const unsigned char *payload, int size, unsigned char **response, int *response_size)
 {
   LogInfo("Try to invoke method %s", methodName);
   const char *responseMessage = "\"Successfully invoke device method\"";
@@ -84,12 +105,12 @@ static int  DeviceMethodCallback(const char *methodName, const unsigned char *pa
 
   if (strcmp(methodName, "start") == 0)
   {
-    LogInfo("Start sending temperature and humidity data");
+    LogInfo("Start sending temperature, humidity and pressure data");
     messageSending = true;
   }
   else if (strcmp(methodName, "stop") == 0)
   {
-    LogInfo("Stop sending temperature and humidity data");
+    LogInfo("Stop sending temperature, humidity and pressure data");
     messageSending = false;
   }
   else
@@ -105,21 +126,24 @@ static int  DeviceMethodCallback(const char *methodName, const unsigned char *pa
   return result;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Arduino sketch
+//-----------------------------------------------------------------------------------------------------------------
 void setup()
 {
+  // put your setup code here, to run once:
   Screen.init();
   Screen.print(0, "IoT DevKit");
-  Screen.print(2, "Initializing...");
+  Screen.print(1, "Initializing...");
+  delay(500);
   
-  Screen.print(3, " > Serial");
+  Screen.print(2, " > Serial");
   Serial.begin(115200);
 
   // Initialize the WiFi module
   Screen.print(3, " > WiFi");
   hasWifi = false;
-  InitWifi();
+  InitWiFi();
   if (!hasWifi)
   {
     return;
@@ -127,13 +151,20 @@ void setup()
 
   LogTrace("HappyPathSetup", NULL);
 
-  Screen.print(3, " > Sensors");
+  // Initialize LEDs
+  Screen.print(2, " > Inet LEDs");
+  delay(500);
+  blinkLED();
+  
+  Screen.print(2, " > Init Sensors");
+  delay(500);
   SensorInit();
 
   Screen.print(3, " > IoT Hub");
-  DevKitMQTTClient_SetOption(OPTION_MINI_SOLUTION_NAME, "DevKit-GetStarted");
+  delay(500);
+  
   DevKitMQTTClient_Init(true);
-
+  DevKitMQTTClient_SetOption(OPTION_MINI_SOLUTION_NAME, "IoT-DevKit-MXChip");
   DevKitMQTTClient_SetSendConfirmationCallback(SendConfirmationCallback);
   DevKitMQTTClient_SetMessageCallback(MessageCallback);
   DevKitMQTTClient_SetDeviceTwinCallback(DeviceTwinCallback);
@@ -142,18 +173,19 @@ void setup()
   send_interval_ms = SystemTickCounterRead();
 }
 
+//-----------------------------------------------------------------------------------------------------------------
 void loop()
 {
+  // put your main code here, to run repeatedly:
   if (hasWifi)
   {
-    if (messageSending && 
-        (int)(SystemTickCounterRead() - send_interval_ms) >= getInterval())
+    if (messageSending && (int)(SystemTickCounterRead() - send_interval_ms) >= getInterval())
     {
-      // Send teperature data
+      // Send temperature data
       char messagePayload[MESSAGE_MAX_LEN];
 
       bool temperatureAlert = readMessage(messageCount, messagePayload, &temperature, &humidity);
-      EVENT_INSTANCE* message = DevKitMQTTClient_Event_Generate(messagePayload, MESSAGE);
+      EVENT_INSTANCE *message = DevKitMQTTClient_Event_Generate(messagePayload, MESSAGE);
       DevKitMQTTClient_Event_AddProp(message, "temperatureAlert", temperatureAlert ? "true" : "false");
       DevKitMQTTClient_SendEventInstance(message);
       
@@ -164,5 +196,5 @@ void loop()
       DevKitMQTTClient_Check();
     }
   }
-  delay(1000);
+  delay(1000);  // Every 1 second delay
 }

--- a/Device/utility.cpp
+++ b/Device/utility.cpp
@@ -1,27 +1,54 @@
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. 
+// Licensed under the MIT license.
 
-#include "HTS221Sensor.h"
 #include "AzureIotHub.h"
 #include "Arduino.h"
+#include "HTS221Sensor.h"  //Humidity and Temperature
+#include "LPS22HBSensor.h" //Pressure
+#include "LIS2MDLSensor.h" //Magnetometer
+#include "LSM6DSLSensor.h" //Accelerometer and Gyroscope
 #include "parson.h"
 #include "config.h"
 #include "RGB_LED.h"
 
 #define RGB_LED_BRIGHTNESS 32
 
+// Peripherals
 DevI2C *i2c;
-HTS221Sensor *sensor;
+HTS221Sensor *tempSensor;
+LPS22HBSensor *pressureSensor;
+LIS2MDLSensor *magneticSensor;
+LSM6DSLSensor *accelgyroSensor;
 static RGB_LED rgbLed;
-static int interval = INTERVAL;
-static float humidity;
-static float temperature;
 
+// Temperature sensor variables
+static unsigned char tempSensorId;
+static float temperature;
+static float humidity;
+static float pressure;
+
+// Accelerometer, pedometer variables
+static unsigned char accelGyroId;
+static int stepCount;
+static int xAxesData[3];
+static int gAxesData[3];
+// int32_t axes[3];
+// int16_t raws[3];
+
+// Magnetic variables
+static unsigned char magSensorId;
+static int mAxes[3];
+
+// Message to Cloud variables
+static int interval = INTERVAL;
+
+//-----------------------------------------------------------------------------------------------------------------
 int getInterval()
 {
     return interval;
 }
 
+//-----------------------------------------------------------------------------------------------------------------
 void blinkLED()
 {
     rgbLed.turnOff();
@@ -30,6 +57,7 @@ void blinkLED()
     rgbLed.turnOff();
 }
 
+//-----------------------------------------------------------------------------------------------------------------
 void blinkSendConfirmation()
 {
     rgbLed.turnOff();
@@ -38,6 +66,7 @@ void blinkSendConfirmation()
     rgbLed.turnOff();
 }
 
+//-----------------------------------------------------------------------------------------------------------------
 void parseTwinMessage(DEVICE_TWIN_UPDATE_STATE updateState, const char *message)
 {
     JSON_Value *root_value;
@@ -74,36 +103,112 @@ void parseTwinMessage(DEVICE_TWIN_UPDATE_STATE updateState, const char *message)
     json_value_free(root_value);
 }
 
+//-----------------------------------------------------------------------------------------------------------------
 void SensorInit()
 {
+    // instantiate a helper class of type DevI2C which will handle the details of I2C peripherals. We also need to pass 2 parameters to the instantiation of this helper class which correspond to GPIO pins 18 and 17 respectively (D14=GPIO_18, D15=GPIO_17).
     i2c = new DevI2C(D14, D15);
-    sensor = new HTS221Sensor(*i2c);
-    sensor->init(NULL);
+
+    // Initialize the temperature sensor
+    Screen.print(3, " > Temperature sensor");
+	delay(500);
+    tempSensor = new HTS221Sensor(*i2c);
+    tempSensor->init(NULL);
+
+    // Initialize the pressure sensor
+    Screen.print(3, " > Pressure sensor");
+	delay(500);
+    pressureSensor = new LPS22HBSensor(*i2c);
+    pressureSensor->init(NULL);
+
+    // Initialize the magnetic sensor
+    Screen.print(3, " > Magnetic sensor");
+    delay(500);
+    magneticSensor = new LIS2MDLSensor(*i2c);
+    magneticSensor->init(NULL);
+
+    // Initialize the motion sensor
+    Screen.print(3, " > Motion sensor");
+	delay(500);
+    accelgyroSensor = new LSM6DSLSensor(*i2c, D4, D5);
+    accelgyroSensor->init(NULL);
+    accelgyroSensor->enableAccelerator();
+    accelgyroSensor->enableGyroscope();
+    accelgyroSensor->enablePedometer();
+    accelgyroSensor->setPedometerThreshold(LSM6DSL_PEDOMETER_THRESHOLD_MID_LOW);
+
+    stepCount = 0;
 
     humidity = -1;
     temperature = -1000;
+    pressure = 0;
 }
 
+//-----------------------------------------------------------------------------------------------------------------
 float readTemperature()
 {
-    sensor->reset();
+    tempSensor->reset();
 
     float temperature = 0;
-    sensor->getTemperature(&temperature);
+    tempSensor->getTemperature(&temperature);
 
     return temperature;
 }
 
+//-----------------------------------------------------------------------------------------------------------------
 float readHumidity()
 {
-    sensor->reset();
+    tempSensor->reset();
 
     float humidity = 0;
-    sensor->getHumidity(&humidity);
+    tempSensor->getHumidity(&humidity);
 
     return humidity;
 }
 
+//-----------------------------------------------------------------------------------------------------------------
+float readPressure()
+{
+    float pressure = 0;
+    pressureSensor->getPressure(&pressure);
+    return pressure;
+}
+
+//-----------------------------------------------------------------------------------------------------------------
+void readAccelerometer()
+{
+    // Read accelerometer sensor
+    accelgyroSensor->getXAxes(xAxesData);
+    Serial.printf("Accelerometer X Axes: x=%d, y=%d, z=%d\n", xAxesData[0], xAxesData[1], xAxesData[2]);
+}
+
+//-----------------------------------------------------------------------------------------------------------------
+void readGyroscope()
+{
+    // Read gyroscope sensor
+    accelgyroSensor->getGAxes(gAxesData);
+    Serial.printf("Gyroscope G Axes: x=%d, y=%d, z=%d\n", gAxesData[0], gAxesData[1], gAxesData[2]);
+}
+
+//-----------------------------------------------------------------------------------------------------------------
+void readMagnetometer()
+{
+    // Read magnetic sensor
+    magneticSensor->readId(&magSensorId);
+    magneticSensor->getMAxes(mAxes);
+    Serial.printf("magSensorId: %d\n", magSensorId);
+    Serial.printf("Magnetometer Axes: x=%d, y=%d, z=%d\n", mAxes[0], mAxes[1], mAxes[2]);
+}
+
+//-----------------------------------------------------------------------------------------------------------------
+int readPedometer()
+{
+    int stepCount = 0;
+    accelgyroSensor->getStepCounter(&stepCount);
+    return stepCount;
+}
+
+//-----------------------------------------------------------------------------------------------------------------
 bool readMessage(int messageId, char *payload, float *temperatureValue, float *humidityValue)
 {
     JSON_Value *root_value = json_value_init_object();
@@ -112,34 +217,67 @@ bool readMessage(int messageId, char *payload, float *temperatureValue, float *h
 
     json_object_set_number(root_object, "messageId", messageId);
 
+    // Obtain values
     float t = readTemperature();
     float h = readHumidity();
+    float p = readPressure();
+	readGyroscope();
+    readAccelerometer();
+	readMagnetometer();
+    readPedometer();
+	
     bool temperatureAlert = false;
-    if(t != temperature)
+	// Set Temp JSON
+    if (t != temperature)
     {
         temperature = t;
         *temperatureValue = t;
         json_object_set_number(root_object, "temperature", temperature);
     }
-    if(temperature > TEMPERATURE_ALERT)
+    if (temperature > TEMPERATURE_ALERT)
     {
         temperatureAlert = true;
     }
-    
-    if(h != humidity)
+
+    // Set Humidity json
+    if (h != humidity)
     {
         humidity = h;
         *humidityValue = h;
         json_object_set_number(root_object, "humidity", humidity);
     }
+
+    // Set Pressure JSON
+    if (p != pressure)
+    {
+        pressure = p;
+        json_object_set_number(root_object, "pressure", pressure);
+    }
+	// Set gyro axes
+    json_object_set_number(root_object, "accelX", xAxesData[0]);
+    json_object_set_number(root_object, "accelY", xAxesData[1]);
+    json_object_set_number(root_object, "accelZ", xAxesData[2]);
+
+    // Set gyro axes
+    json_object_set_number(root_object, "gccelX", gAxesData[0]);
+    json_object_set_number(root_object, "gccelY", gAxesData[1]);
+    json_object_set_number(root_object, "gccelZ", gAxesData[2]);
+  
+    // Set mag axes
+    json_object_set_number(root_object, "magX", mAxes[0]);
+    json_object_set_number(root_object, "magY", mAxes[1]);
+    json_object_set_number(root_object, "magZ", mAxes[2]);
+
     serialized_string = json_serialize_to_string_pretty(root_value);
 
     snprintf(payload, MESSAGE_MAX_LEN, "%s", serialized_string);
     json_free_serialized_string(serialized_string);
     json_value_free(root_value);
+	
     return temperatureAlert;
 }
 
+//-----------------------------------------------------------------------------------------------------------------
 #if (DEVKIT_SDK_VERSION >= 10602)
 void __sys_setup(void)
 {

--- a/Device/utility.h
+++ b/Device/utility.h
@@ -4,13 +4,22 @@
 #ifndef UTILITY_H
 #define UTILITY_H
 
-void parseTwinMessage(DEVICE_TWIN_UPDATE_STATE, const char *);
-bool readMessage(int, char *, float *, float *);
+//-----------------------------------------------------------------------------------------------------------------
+int getInterval(void);
 
+//-----------------------------------------------------------------------------------------------------------------
+void blinkLED(void);
+
+//-----------------------------------------------------------------------------------------------------------------
+void blinkSendConfirmation(void);
+
+//-----------------------------------------------------------------------------------------------------------------
+void parseTwinMessage(DEVICE_TWIN_UPDATE_STATE, const char *);
+
+//-----------------------------------------------------------------------------------------------------------------
 void SensorInit(void);
 
-void blinkLED(void);
-void blinkSendConfirmation(void);
-int getInterval(void);
+//-----------------------------------------------------------------------------------------------------------------
+bool readMessage(int, char *, float *, float *);
 
 #endif /* UTILITY_H */

--- a/GetStarted.code-workspace
+++ b/GetStarted.code-workspace
@@ -6,6 +6,10 @@
     ],
     "settings": {
         "IoTWorkbench.BoardId": "devkit",
-        "IoTWorkbench.DevicePath": "Device"
+        "IoTWorkbench.DevicePath": "Device",
+        "files.associations": {
+            "*.ps1": "powershell",
+            "new": "cpp"
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ A device must be registered with your IoT hub before it can connect. In this qui
    **YourIoTHubName**: Replace this placeholder below with the name you choose for your IoT hub.
 
     ```azurecli-interactive
-    az iot hub device-identity show-connection-string --hub-name YourIoTHubName --device-id MyNodeDevice --output table
+    az iot hub device-identity connection-string show --hub-name YourIoTHubName --device-id MyNodeDevice --output table
     ```
 
     Make a note of the device connection string, which looks like:

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ A device must be registered with your IoT hub before it can connect. In this qui
     az iot hub device-identity connection-string show --hub-name YourIoTHubName --device-id MyNodeDevice --output table
     ```
 
-    Make a note of the device connection string, which looks like:
+    Make a note of the device connection string, which looks like this:
 
    `HostName={YourIoTHubName}.azure-devices.net;DeviceId=MyNodeDevice;SharedAccessKey={YourSharedAccessKey}`
 


### PR DESCRIPTION
Updating the azure cli for how to show the device connection string:
Original command:
az iot hub device-identity show-connection-string --hub-name YourIoTHubName --device-id MyNodeDevice --output table

Command should be: 
az iot hub device-identity connection-string show --hub-name YourIoTHubName --device-id MyNodeDevice --output table

see: https://docs.microsoft.com/en-us/cli/azure/iot/hub/device-identity/connection-string?view=azure-cli-latest#az_iot_hub_device_identity_connection_string_show